### PR TITLE
adds generating the skeleton automatically with shared secrets, consul certs, etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:14.04
+#dpkg-query --show
+RUN apt-get update && apt-get install -y \
+  autoconf=2.69-6 \
+  awscli=1.2.9-2 \
+  bison=2:3.0.2.dfsg-2 \
+  build-essential=11.6ubuntu6 \
+  curl=7.35.0-1ubuntu2.5 \
+  gcc=4:4.8.2-1ubuntu6 \
+  git=1:1.9.1-1ubuntu0.1 \
+  jq=1.3-1.1ubuntu1 \
+  libffi-dev:amd64=3.1~rc1+r3.0.13-12 \
+  libgdbm-dev=1.8.3-12build1 \
+  libgdbm3:amd64=1.8.3-12build1 \
+  libncurses5-dev:amd64=5.9+20140118-1ubuntu1 \
+  libreadline6-dev:amd64=6.3-4ubuntu2 \
+  libsqlite3-dev:amd64=3.8.2-1ubuntu2.1 \
+  libssl-dev:amd64=1.0.1f-1ubuntu2.15 \
+  libxml2-dev:amd64=2.9.1+dfsg1-3ubuntu4.4 \
+  libxslt1-dev=1.1.28-2build1 \
+  libyaml-dev:amd64=0.1.4-3ubuntu3.1 \
+  make=3.81-8.2ubuntu3 \
+  openssl=1.0.1f-1ubuntu2.15 \
+  sqlite3=3.8.2-1ubuntu2.1 \
+  unzip=6.0-9ubuntu1.3 \
+  zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
+  zlibc=0.9k-4.1
+
+RUN cd /root && \
+  curl -L -J -O https://cache.ruby-lang.org/pub/ruby/2.2/ruby-2.2.3.tar.gz && \
+  tar xf ruby-2.2.3.tar.gz && \
+  cd /root/ruby-2.2.3 && \
+  ./configure --prefix=/usr/local && \
+  make && \
+  make install
+
+RUN gem install bosh_cli -v 1.3071.0
+
+RUN cd /root && \
+ curl -L -J -O https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz && \
+ tar xf go1.5.linux-amd64.tar.gz && \
+ mv go /usr/local/go
+ENV PATH /usr/local/go/bin:$PATH
+
+RUN cd /root && \
+  git clone https://github.com/square/certstrap && \
+  cd certstrap && \
+  git checkout 9741482cae85edb8f2c3f147428ec2621d849809 && \
+  ./build && \
+  mv bin/certstrap /usr/local/bin/certstrap
+
+RUN cd /root && \
+  curl -L -J -O https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.72-linux-amd64 && \
+  mv bosh-init-* /usr/local/bin/bosh-init && \
+  chmod +x /usr/local/bin/bosh-init
+
+RUN cd /root && \
+  curl -L -J -O https://github.com/cloudfoundry-incubator/spiff/releases/download/v1.0.7/spiff_linux_amd64.zip && \
+  unzip spiff_linux_amd64.zip && \
+  mv spiff /usr/local/bin/spiff
+
+RUN cd /root && \
+  rm -Rf *
+
+RUN echo "Checking that all dependencies are installed..." && \
+  aws --version && \
+  bosh --version && \
+  printf "bosh-init " && \
+  bosh-init --version && \
+  certstrap --version && \
+  git --version && \
+  jq --version && \
+  openssl version && \
+  spiff --version

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ information for your planned deployment as described below.
 * The `certstrap` command line tool. This is used to generate the ssl certificates needed
   for consul. This can be installed by running `go get -v github.com/square/certstrap`.
 
+Alternatively, you can use the Dockerfile included in this repository to create
+an environment with the necessary programs.
+
 ## Deployment Directory Details
 
 Minimal folder structure requirments:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ bosh_credentials:
   registry_password: REPLACE_WITH_PASSWORD
 ```
 
+In addition, the bosh credentials yml can be generated with:
+
+```bash
+./scripts/generate_bosh_passwords
+```
+
 ## Setting up Your AWS Environment and Deploying BOSH
 
 Run:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ information for your planned deployment as described below.
 
 * The `openssl` command line tool. 
 
+* The `certstrap` command line tool. This is used to generate the ssl certificates needed
+  for consul. This can be installed by running `go get -v github.com/square/certstrap`.
+
 ## Deployment Directory Details
 
 Minimal folder structure requirments:

--- a/README.md
+++ b/README.md
@@ -382,6 +382,12 @@ The `stubs/cf/cf-stub.yml` will be your primary manifest stub for your Cloud Fou
 want to make should be made here. Certain values will be merged into this stub by default. See the `example_stubs/cf`
 directory for example stubs. Also read `example_stubs/cf/README` for instructions on filling out the stubs.
 
+In addition, the shared secrets needed for CF can be generated with:
+
+```bash
+./scripts/generate_shared_secrets_stub
+```
+
 [concourse-releases]: https://github.com/concourse/concourse/releases
 [bosh-init-docs]: https://bosh.io/docs/install-bosh-init.html
 [bosh-stemcells]: http://bosh.io/stemcells

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ information for your planned deployment as described below.
 * The `spiff` command line tool. The latest release can be found [here]
   [spiff-releases].
 
+* The `openssl` command line tool. 
 
 ## Deployment Directory Details
 

--- a/example_stubs/cf/single_az.yml
+++ b/example_stubs/cf/single_az.yml
@@ -183,6 +183,10 @@ properties:
     agent_key: |
       REPLACE_WITH_CONSUL_AGENT_KEY
 jobs:
+  - name: api_z2
+    instances: 0
+  - name: api_worker_z2
+    instances: 0
   - name: consul_z1
     instances: 1
   - name: consul_z2
@@ -193,11 +197,19 @@ jobs:
     instances: 1
   - name: etcd_z2
     instances: 0
+  - name: hm9000_z2
+    instances: 0
   - name: loggregator_trafficcontroller_z2
     instances: 0
   - name: nats_z2
     instances: 0
   - name: router_z2
     instances: 0
+  - name: runner_z2
+    instances: 0
   - name: smoke_tests
     instances: 1
+  - name: stats_z2
+    instances: 0
+  - name: uaa_z2
+    instances: 0

--- a/scripts/deploy_cf_bosh_instance
+++ b/scripts/deploy_cf_bosh_instance
@@ -97,14 +97,12 @@ mkdir -p ${deployment_dir}/generated-stubs/cf
 mkdir -p generated-stubs
 
 # create keypair
-if ! aws ec2 describe-key-pairs --key-names bosh; then
-  aws ec2 create-key-pair --key-name bosh | jq -r .KeyMaterial > ${deployment_dir}/artifacts/keypair/id_rsa_bosh
-fi
+aws ec2 delete-key-pair --key-name bosh
+aws ec2 create-key-pair --key-name bosh | jq -r .KeyMaterial > ${deployment_dir}/artifacts/keypair/id_rsa_bosh
 
 # install certs for CF ELB
-if ! aws iam get-server-certificate --server-certificate-name cf; then
-  aws iam upload-server-certificate --server-certificate-name cf --private-key file://${deployment_dir}/certs/cf.key --certificate-body file://${deployment_dir}/certs/cf.pem
-fi
+aws iam delete-server-certificate --server-certificate-name cf; 
+aws iam upload-server-certificate --server-certificate-name cf --private-key file://${deployment_dir}/certs/cf.key --certificate-body file://${deployment_dir}/certs/cf.pem
 
 # deploy cloud formation templates
 deploy_bosh_and_cf

--- a/scripts/generate_bosh_passwords
+++ b/scripts/generate_bosh_passwords
@@ -1,16 +1,16 @@
 #/bin/bash
 set -e
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
-. "$DIR/generate_random_string"
+
+dir=$(dirname $0)
+generate_random_string="$dir/generate_random_string"
 
 cat << EOM
 bosh_credentials:
-  agent_password: $(generate_random_string)
-  director_password: $(generate_random_string)
-  mbus_password: $(generate_random_string)
-  nats_password: $(generate_random_string)
-  redis_password: $(generate_random_string)
-  postgres_password: $(generate_random_string)
-  registry_password: $(generate_random_string)
+  agent_password: $($generate_random_string)
+  director_password: $($generate_random_string)
+  mbus_password: $($generate_random_string)
+  nats_password: $($generate_random_string)
+  redis_password: $($generate_random_string)
+  postgres_password: $($generate_random_string)
+  registry_password: $($generate_random_string)
 EOM

--- a/scripts/generate_bosh_passwords
+++ b/scripts/generate_bosh_passwords
@@ -1,0 +1,16 @@
+#/bin/bash
+set -e
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/generate_random_string"
+
+cat << EOM
+bosh_credentials:
+  agent_password: $(generate_random_string)
+  director_password: $(generate_random_string)
+  mbus_password: $(generate_random_string)
+  nats_password: $(generate_random_string)
+  redis_password: $(generate_random_string)
+  postgres_password: $(generate_random_string)
+  registry_password: $(generate_random_string)
+EOM

--- a/scripts/generate_json_web_token_keys
+++ b/scripts/generate_json_web_token_keys
@@ -1,0 +1,23 @@
+#/bin/bash
+set -e
+command -v openssl >/dev/null || { echo "openssl is required"; exit 1; }
+
+dir=$(dirname $0)
+generate_random_string="$dir/generate_random_string"
+
+signing_key_location=$(mktemp || mktemp -t private)
+verification_key_location=$(mktemp || mktemp -t public)
+
+openssl genrsa -out $signing_key_location 2048 
+openssl rsa -in $signing_key_location -pubout > $verification_key_location
+
+signing_key=$(cat $signing_key_location)
+rm $signing_key_location
+verification_key=$(cat $verification_key_location)
+rm $verification_key_location
+
+cat << EOF
+$signing_key
+
+$verification_key
+EOF

--- a/scripts/generate_new_cf_deployment_dir
+++ b/scripts/generate_new_cf_deployment_dir
@@ -1,0 +1,128 @@
+#/bin/bash
+set -e
+
+command -v openssl >/dev/null || { echo "openssl is required"; exit 1; }
+command -v git >/dev/null || { echo "git is required"; exit 1; }
+
+dir=$(dirname $0)
+generate_bosh_passwords="$dir/generate_bosh_passwords"
+generate_shared_secrets_stub="$dir/generate_shared_secrets_stub"
+generate_random_string="$dir/generate_random_string"
+
+: ${AWS_ACCESS_KEY_ID:?"Must set AWS_ACCESS_KEY_ID (e.g. AKIAIOSFODNN7EXAMPLE)"}
+: ${AWS_DEFAULT_REGION:?"Must set AWS_DEFAULT_REGION (e.g. us-east-1)"}
+: ${AWS_SECRET_ACCESS_KEY:?"Must set AWS_SECRET_ACCESS_KEY (e.g. wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY)"}
+: ${DEPLOYMENT_DIR:?"Must set DEPLOYMENT_DIR (e.g. ferret, will abort if exists)"}
+: ${DOMAIN_NAME:?"Must set DOMAIN_NAME that will point to CF (e.g. hello.com)"}
+
+if [ -d $DEPLOYMENT_DIR ]; then
+  echo "$DEPLOYMENT_DIR already exists. Aborting..."
+  exit
+fi
+
+echo "Creating directory structure..."
+mkdir -p $DEPLOYMENT_DIR/certs
+mkdir -p $DEPLOYMENT_DIR/cloud_formation
+mkdir -p $DEPLOYMENT_DIR/stubs/bosh
+mkdir -p $DEPLOYMENT_DIR/stubs/cf
+
+absolute_deployment_path="$( cd "$( dirname $DEPLOYMENT_DIR )" && echo "$PWD/$DEPLOYMENT_DIR" )"
+deployment_name=$(basename $absolute_deployment_path)
+
+echo "Creating bosh_passwords.yml..."
+$generate_bosh_passwords > $absolute_deployment_path/stubs/bosh/bosh_passwords.yml
+
+echo "Creating aws_environment file..."
+cat > $absolute_deployment_path/aws_environment <<EOF
+export AWS_DEFAULT_REGION="$AWS_DEFAULT_REGION"
+export AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+EOF
+
+echo "Creating cf-properties.json..."
+cat > $absolute_deployment_path/cloud_formation/cf-properties.json <<EOF
+[
+  {
+    "ParameterKey": "CFHostedZoneName",
+    "ParameterValue": "$DOMAIN_NAME"
+  },
+  {
+    "ParameterKey": "CFAppsDomainHostedZoneName",
+    "ParameterValue": "$DOMAIN_NAME"
+  },
+  {
+    "ParameterKey": "CCDBUsername",
+    "ParameterValue": "admin"
+  },
+  {
+    "ParameterKey": "CCDBPassword",
+    "ParameterValue": "$($generate_random_string)"
+  },
+  {
+    "ParameterKey": "UAADBUsername",
+    "ParameterValue": "admin"
+  },
+  {
+    "ParameterKey": "UAADBPassword",
+    "ParameterValue": "$($generate_random_string)"
+  }
+]
+EOF
+
+echo "Creating buckets-properties.json..."
+domain_name_s3_safe=$(echo $DOMAIN_NAME | sed -e 's/\./\-/')
+cat > $absolute_deployment_path/cloud_formation/buckets-properties.json <<EOF
+[
+  {
+    "ParameterKey": "CCBuildpacksBucketName",
+    "ParameterValue": "${domain_name_s3_safe}-cc-buildpacks"
+  },
+  {
+    "ParameterKey": "CCDropletsBucketName",
+    "ParameterValue": "${domain_name_s3_safe}-cc-droplets"
+  },
+  {
+    "ParameterKey": "CCPackagesBucketName",
+    "ParameterValue": "${domain_name_s3_safe}-cc-packages"
+  },
+  {
+    "ParameterKey": "CCResourcesBucketName",
+    "ParameterValue": "${domain_name_s3_safe}-cc-resources"
+  },
+  {
+    "ParameterKey": "AcceptanceTestLogsBucketName",
+    "ParameterValue": "$domain_name_s3_safe-cat-logs"
+  }
+]
+EOF
+
+echo "WARNING: Skipped setting up Cloud Front CDN (optional)."
+
+echo "Creating environment.yml"
+cat > $absolute_deployment_path/stubs/cf/environment.yml <<EOF
+meta:
+  environment: $deployment_name
+EOF
+
+echo "Creating shared_secrets.yml [this may take a few minutes]..."
+$generate_shared_secrets_stub > $absolute_deployment_path/stubs/cf/shared_secrets.yml
+
+echo "Creating self-signed.yml"
+cat > $absolute_deployment_path/stubs/cf/self-signed.yml <<EOF
+properties:
+  ssl:
+    skip_cert_verify: true
+  acceptance_tests:
+    skip_ssl_validation: true
+  smoke_tests:
+    skip_ssl_validation: true
+EOF
+
+echo "Creating self signed certificate..."
+openssl genrsa -out "$absolute_deployment_path/certs/cf.key" 1024
+chmod 400 "$absolute_deployment_path/certs/cf.key"
+openssl req -new -subj "/CN=*.$DOMAIN_NAME" -key "$absolute_deployment_path/certs/cf.key" -out "$absolute_deployment_path/certs/cf.csr"
+openssl x509 -req -in "$absolute_deployment_path/certs/cf.csr" -signkey "$absolute_deployment_path/certs/cf.key" -out "$absolute_deployment_path/certs/cf.pem"
+
+echo "Committing to git..."
+cd $absolute_deployment_path && git init && git add -A && git commit -m "init commit"

--- a/scripts/generate_random_string
+++ b/scripts/generate_random_string
@@ -1,7 +1,3 @@
 #/bin/bash
 set -e
-
-function generate_random_string()
-{
-    dd if=/dev/urandom | env LC_CTYPE=C tr -cd 'a-zA-Z0-9' | head -c 32
-}
+dd if=/dev/urandom | env LC_CTYPE=C tr -cd 'a-zA-Z0-9' | head -c 32

--- a/scripts/generate_random_string
+++ b/scripts/generate_random_string
@@ -1,0 +1,7 @@
+#/bin/bash
+set -e
+
+function generate_random_string()
+{
+    dd if=/dev/urandom | env LC_CTYPE=C tr -cd 'a-zA-Z0-9' | head -c 32
+}

--- a/scripts/generate_shared_secrets_stub
+++ b/scripts/generate_shared_secrets_stub
@@ -1,0 +1,82 @@
+#/bin/bash
+set -e
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/generate_random_string"
+
+
+function generate_json_web_token_keys()
+{
+  local _outvar1=$1
+  local _outvar2=$2
+  local _signing_key_location
+  local _verification_key_location
+  local _signing_key
+  local _verification_key
+
+  _signing_key_location=$(mktemp /tmp/privXXXXXX)
+  _verification_key_location=$(mktemp /tmp/pubXXXXXX)
+
+  openssl genrsa -out $_signing_key_location 2048 
+  openssl rsa -in $_signing_key_location -pubout > $_verification_key_location
+
+  _signing_key=$(sed -e 's/^/        /' $_signing_key_location)
+  rm $_signing_key_location
+  _verification_key=$(sed -e 's/^/        /' $_verification_key_location)
+  rm $_verification_key_location
+
+  eval $_outvar1=\$_signing_key
+  eval $_outvar2=\$_verification_key
+}
+
+cloud_controller_admin_password=$(generate_random_string)
+
+generate_json_web_token_keys signing_key verification_key
+
+cat << EOM
+properties:
+  acceptance_tests:
+    admin_password: ${cloud_controller_admin_password}
+  cc:
+    staging_upload_user: $(generate_random_string)
+    bulk_api_password: $(generate_random_string)
+    staging_upload_password: $(generate_random_string)
+    db_encryption_key: $(generate_random_string)
+  loggregator_endpoint:
+    shared_secret: $(generate_random_string)
+  nats:
+    password: $(generate_random_string)
+  router:
+    status:
+      password: $(generate_random_string)
+    route_service_secret: $(generate_random_string)
+  smoke_tests:
+    password: ${cloud_controller_admin_password}
+  uaa:
+    admin:
+      client_secret: $(generate_random_string)
+    batch:
+      username: $(generate_random_string)
+      password: $(generate_random_string)
+    cc:
+      client_secret: $(generate_random_string)
+    clients:
+      cloud_controller_username_lookup:
+        secret: $(generate_random_string)
+      doppler:
+        secret: $(generate_random_string)
+      gorouter:
+        secret: $(generate_random_string)
+      login:
+        secret: $(generate_random_string)
+      notifications:
+        secret: $(generate_random_string)
+    jwt:
+      signing_key: |
+${signing_key}
+      verification_key: |
+${verification_key}
+    scim:
+      users: 
+      - "admin|${cloud_controller_admin_password}|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose"
+EOM

--- a/scripts/generate_shared_secrets_stub
+++ b/scripts/generate_shared_secrets_stub
@@ -1,82 +1,125 @@
 #/bin/bash
 set -e
-DIR="${BASH_SOURCE%/*}"
-if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
-. "$DIR/generate_random_string"
+command -v certstrap >/dev/null || { echo "certstrap is required"; exit 1; }
+command -v base64 >/dev/null || { echo "base64 is required"; exit 1; }
 
-
-function generate_json_web_token_keys()
+function generate_consul_certs()
 {
-  local _outvar1=$1
-  local _outvar2=$2
-  local _signing_key_location
-  local _verification_key_location
-  local _signing_key
-  local _verification_key
+  local _depot_path=$(mktemp -d || mktemp -d -t depot)
+  # CA to distribute to consul agent and servers
+  certstrap --depot-path ${_depot_path} init --passphrase '' --common-name consulCA 1>&2
+  mv -f ${_depot_path}/consulCA.crt ${_depot_path}/server-ca.crt
+  mv -f ${_depot_path}/consulCA.key ${_depot_path}/server-ca.key
 
-  _signing_key_location=$(mktemp /tmp/privXXXXXX)
-  _verification_key_location=$(mktemp /tmp/pubXXXXXX)
+  # Server certificate to share across the consul cluster
+  server_cn=server.dc1.cf.internal
+  certstrap --depot-path ${_depot_path} request-cert --passphrase '' --common-name $server_cn 1>&2
+  certstrap --depot-path ${_depot_path} sign $server_cn --CA server-ca 1>&2
+  mv -f ${_depot_path}/$server_cn.key ${_depot_path}/server.key
+  mv -f ${_depot_path}/$server_cn.csr ${_depot_path}/server.csr
+  mv -f ${_depot_path}/$server_cn.crt ${_depot_path}/server.crt
 
-  openssl genrsa -out $_signing_key_location 2048 
-  openssl rsa -in $_signing_key_location -pubout > $_verification_key_location
+  # Agent certificate to distribute to jobs that access consul
+  certstrap --depot-path ${_depot_path} request-cert --passphrase '' --common-name 'consul agent' 1>&2
+  certstrap --depot-path ${_depot_path} sign consul_agent --CA server-ca 1>&2
+  mv -f ${_depot_path}/consul_agent.key ${_depot_path}/agent.key
+  mv -f ${_depot_path}/consul_agent.csr ${_depot_path}/agent.csr
+  mv -f ${_depot_path}/consul_agent.crt ${_depot_path}/agent.crt
 
-  _signing_key=$(sed -e 's/^/        /' $_signing_key_location)
-  rm $_signing_key_location
-  _verification_key=$(sed -e 's/^/        /' $_verification_key_location)
-  rm $_verification_key_location
-
-  eval $_outvar1=\$_signing_key
-  eval $_outvar2=\$_verification_key
+  echo $_depot_path
 }
 
-cloud_controller_admin_password=$(generate_random_string)
+depot_path=$(generate_consul_certs)
 
-generate_json_web_token_keys signing_key verification_key
+dir=$(dirname $0)
+generate_random_string="$dir/generate_random_string"
+generate_json_web_token_keys="$dir/generate_json_web_token_keys"
+
+cloud_controller_admin_password=$($generate_random_string)
+keys=$($generate_json_web_token_keys)
+
+signing_key=$(echo "$keys" | head -n 27)
+verification_key=$(echo "$keys" | tail -n 9)
+
+function format_consul_key()
+{
+  sed 's/^/      /' "$1"
+}
+
+function format_jwt_key()
+{
+  echo "$1" | sed 's/^/        /'
+}
+
+signing_key=$(format_jwt_key "$signing_key")
+verification_key=$(format_jwt_key "$verification_key")
+
+consul_encrypt_key=$(dd if=/dev/urandom bs=16 count=1| base64)
+consul_ca_crt=$(format_consul_key "$depot_path/server-ca.crt")
+consul_server_crt=$(format_consul_key "$depot_path/server.crt")
+consul_server_key=$(format_consul_key "$depot_path/server.key")
+consul_agent_crt=$(format_consul_key "$depot_path/agent.crt")
+consul_agent_key=$(format_consul_key "$depot_path/agent.key")
 
 cat << EOM
 properties:
   acceptance_tests:
     admin_password: ${cloud_controller_admin_password}
   cc:
-    staging_upload_user: $(generate_random_string)
-    bulk_api_password: $(generate_random_string)
-    staging_upload_password: $(generate_random_string)
-    db_encryption_key: $(generate_random_string)
+    staging_upload_user: $($generate_random_string)
+    bulk_api_password: $($generate_random_string)
+    staging_upload_password: $($generate_random_string)
+    db_encryption_key: $($generate_random_string)
+  consul:
+    encrypt_keys: [$consul_encrypt_key]
+    require_ssl: true
+    ca_cert: |
+$consul_ca_crt
+    server_cert: |
+$consul_server_crt
+    server_key: |
+$consul_server_key
+    agent_cert: |
+$consul_agent_crt
+    agent_key: |
+$consul_agent_key
   loggregator_endpoint:
-    shared_secret: $(generate_random_string)
+    shared_secret: $($generate_random_string)
   nats:
-    password: $(generate_random_string)
+    password: $($generate_random_string)
   router:
     status:
-      password: $(generate_random_string)
-    route_service_secret: $(generate_random_string)
+      password: $($generate_random_string)
+    route_service_secret: $($generate_random_string)
   smoke_tests:
     password: ${cloud_controller_admin_password}
   uaa:
     admin:
-      client_secret: $(generate_random_string)
+      client_secret: $($generate_random_string)
     batch:
-      username: $(generate_random_string)
-      password: $(generate_random_string)
+      username: $($generate_random_string)
+      password: $($generate_random_string)
     cc:
-      client_secret: $(generate_random_string)
+      client_secret: $($generate_random_string)
     clients:
       cloud_controller_username_lookup:
-        secret: $(generate_random_string)
+        secret: $($generate_random_string)
       doppler:
-        secret: $(generate_random_string)
+        secret: $($generate_random_string)
       gorouter:
-        secret: $(generate_random_string)
+        secret: $($generate_random_string)
       login:
-        secret: $(generate_random_string)
+        secret: $($generate_random_string)
       notifications:
-        secret: $(generate_random_string)
+        secret: $($generate_random_string)
     jwt:
       signing_key: |
-${signing_key}
+$signing_key
       verification_key: |
-${verification_key}
+$verification_key
     scim:
       users: 
       - "admin|${cloud_controller_admin_password}|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose"
 EOM
+
+rm -Rf $depot_path

--- a/spiff_templates/multi_az.yml
+++ b/spiff_templates/multi_az.yml
@@ -1,0 +1,178 @@
+---
+meta:
+  environment: (( merge ))
+
+cf_databases: (( merge ))
+cf_resources: (( merge ))
+cloud_formation_inputs: (( merge ))
+
+director_uuid: (( merge ))
+
+networks:
+  - name: cf1
+    type: manual
+    subnets:
+      - range: 10.0.15.0/24
+        name: default_unused
+        reserved:
+          - 10.0.15.2 - 10.0.15.9
+        static:
+          - 10.0.15.10 - 10.0.15.100
+        gateway: 10.0.15.1
+        dns:
+          - 10.0.0.2
+        cloud_properties:
+          security_groups: [(( cf_resources.security_group_name ))]
+          subnet: (( cf_resources.subnets.[0].subnet_id ))
+
+  - name: cf2
+    type: manual
+    subnets:
+      - range: 10.0.16.0/24
+        name: default_unused
+        reserved:
+          - 10.0.16.2 - 10.0.16.9
+        static:
+          - 10.0.16.10 - 10.0.16.100
+        gateway: 10.0.16.1
+        dns:
+          - 10.0.0.2
+        cloud_properties:
+          security_groups: [(( cf_resources.security_group_name ))]
+          subnet: (( cf_resources.subnets.[1].subnet_id ))
+resource_pools:
+  - name: router_z1
+    cloud_properties:
+      elbs: [(( cf_resources.elb ))]
+  - name: router_z2
+    cloud_properties:
+      elbs: [(( cf_resources.elb ))]
+
+properties:
+  domain: (( cloud_formation_inputs.CFHostedZoneName ))
+  ssl:
+    skip_cert_verify: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+  system_domain_organization: system
+  app_domains: [(( cloud_formation_inputs.CFAppsDomainHostedZoneName ))]
+  template_only:
+    aws:
+      access_key_id: (( cf_resources.blobstore.access_key ))
+      secret_access_key: (( cf_resources.blobstore.secret_key ))
+      availability_zone: (( cf_resources.subnets.[0].availability_zone ))
+      availability_zone2: (( cf_resources.subnets.[1].availability_zone ))
+
+  ccdb:
+    db_scheme: mysql
+    roles:
+    - tag: admin
+      name: (( cloud_formation_inputs.CCDBUsername ))
+      password: (( cloud_formation_inputs.CCDBPassword ))
+    databases:
+    - tag: cc
+      name: (( cf_databases.ccdb_database ))
+    address: (( cf_databases.ccdb_host ))
+    port: (( cf_databases.ccdb_port ))
+  uaadb:
+    db_scheme: mysql
+    roles:
+    - tag: admin
+      name: (( cloud_formation_inputs.UAADBUsername ))
+      password: (( cloud_formation_inputs.UAADBPassword ))
+    databases:
+    - tag: uaa
+      name: (( cf_databases.uaadb_database ))
+    address: (( cf_databases.uaadb_host ))
+    port: (( cf_databases.uaadb_port ))
+
+  uaa:
+    jwt:
+      signing_key: |
+        (( merge ))
+      verification_key: |
+        (( merge ))
+    cc:
+      client_secret: (( merge ))
+    admin:
+      client_secret: (( merge ))
+    batch:
+      username: (( merge ))
+      password: (( merge ))
+    clients:
+      login:
+        secret: (( merge ))
+      notifications:
+        secret: (( merge ))
+      doppler:
+        secret: (( merge ))
+      cloud_controller_username_lookup:
+        secret: (( merge ))
+      gorouter:
+        secret: (( merge ))
+
+    scim:
+      users: (( merge ))
+
+  nats:
+    user: nats
+    password: (( merge ))
+    monitor_port: 9222
+
+  cc:
+    bulk_api_password: (( merge ))
+    staging_upload_user: (( merge ))
+    staging_upload_password: (( merge ))
+    db_encryption_key: (( merge ))
+    resource_pool: ~
+    droplets: ~
+
+  router:
+    status:
+      user: router
+      password: (( merge ))
+    route_service_secret: (( merge ))
+
+  loggregator_endpoint:
+    shared_secret: (( merge ))
+
+  dea_next:
+    disk_mb: 199000
+    memory_mb: 28001
+
+  collector:
+    deployment_name: (( meta.environment ))
+
+  acceptance_tests:
+    api:  (( "api." domain ))
+    apps_domain: (( app_domains ))
+    system_domain: (( domain ))
+    client_secret: (( uaa.clients.gorouter.secret ))
+    admin_user: admin
+    admin_password: (( merge ))
+    nodes: 3
+    include_sso: false
+    include_services: false
+    include_logging: false
+    include_v3: false
+    include_routing: false
+    skip_ssl_validation: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+    use_diego: false
+    use_http: true
+
+  smoke_tests:
+    api:  (( "api." domain ))
+    apps_domain: (( app_domains ))
+    user: admin
+    password: (( merge ))
+    org: 'smoke-tests'
+    space: 'smoke-tests'
+    use_existing_org: true
+    skip_ssl_validation: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+
+  consul:
+    encrypt_keys: (( merge ))
+    require_ssl: true
+    ca_cert: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
+    agent_cert: (( merge ))
+    agent_key: (( merge ))

--- a/spiff_templates/single_az.yml
+++ b/spiff_templates/single_az.yml
@@ -1,0 +1,209 @@
+---
+meta:
+  environment: (( merge ))
+
+cf_databases: (( merge ))
+cf_resources: (( merge ))
+cloud_formation_inputs: (( merge ))
+
+director_uuid: (( merge ))
+
+networks:
+  - name: cf1
+    type: manual
+    subnets:
+      - range: 10.0.15.0/24
+        name: default_unused
+        reserved:
+          - 10.0.15.2 - 10.0.15.9
+        static:
+          - 10.0.15.10 - 10.0.15.100
+        gateway: 10.0.15.1
+        dns:
+          - 10.0.0.2
+        cloud_properties:
+          security_groups: [(( cf_resources.security_group_name ))]
+          subnet: (( cf_resources.subnets.[0].subnet_id ))
+
+  - name: cf2
+    type: manual
+    subnets:
+      - range: 10.0.16.0/24
+        name: default_unused
+        reserved:
+          - 10.0.16.2 - 10.0.16.9
+        static:
+          - 10.0.16.10 - 10.0.16.100
+        gateway: 10.0.16.1
+        dns:
+          - 10.0.0.2
+        cloud_properties:
+          security_groups: [(( cf_resources.security_group_name ))]
+          subnet: (( cf_resources.subnets.[1].subnet_id ))
+resource_pools:
+  - name: router_z1
+    cloud_properties:
+      elbs: [(( cf_resources.elb ))]
+  - name: router_z2
+    cloud_properties:
+      elbs: [(( cf_resources.elb ))]
+
+properties:
+  domain: (( cloud_formation_inputs.CFHostedZoneName ))
+  ssl:
+    skip_cert_verify: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+  system_domain_organization: system
+  app_domains: [(( cloud_formation_inputs.CFAppsDomainHostedZoneName ))]
+  template_only:
+    aws:
+      access_key_id: (( cf_resources.blobstore.access_key ))
+      secret_access_key: (( cf_resources.blobstore.secret_key ))
+      availability_zone: (( cf_resources.subnets.[0].availability_zone ))
+      availability_zone2: (( cf_resources.subnets.[1].availability_zone ))
+
+  ccdb:
+    db_scheme: mysql
+    roles:
+    - tag: admin
+      name: (( cloud_formation_inputs.CCDBUsername ))
+      password: (( cloud_formation_inputs.CCDBPassword ))
+    databases:
+    - tag: cc
+      name: (( cf_databases.ccdb_database ))
+    address: (( cf_databases.ccdb_host ))
+    port: (( cf_databases.ccdb_port ))
+  uaadb:
+    db_scheme: mysql
+    roles:
+    - tag: admin
+      name: (( cloud_formation_inputs.UAADBUsername ))
+      password: (( cloud_formation_inputs.UAADBPassword ))
+    databases:
+    - tag: uaa
+      name: (( cf_databases.uaadb_database ))
+    address: (( cf_databases.uaadb_host ))
+    port: (( cf_databases.uaadb_port ))
+
+  uaa:
+    jwt:
+      signing_key: |
+        (( merge ))
+      verification_key: |
+        (( merge ))
+    cc:
+      client_secret: (( merge ))
+    admin:
+      client_secret: (( merge ))
+    batch:
+      username: (( merge ))
+      password: (( merge ))
+    clients:
+      login:
+        secret: (( merge ))
+      notifications:
+        secret: (( merge ))
+      doppler:
+        secret: (( merge ))
+      cloud_controller_username_lookup:
+        secret: (( merge ))
+      gorouter:
+        secret: (( merge ))
+
+    scim:
+      users: (( merge ))
+
+  nats:
+    user: nats
+    password: (( merge ))
+    monitor_port: 9222
+
+  cc:
+    bulk_api_password: (( merge ))
+    staging_upload_user: (( merge ))
+    staging_upload_password: (( merge ))
+    db_encryption_key: (( merge ))
+    resource_pool: ~
+    droplets: ~
+
+  router:
+    status:
+      user: router
+      password: (( merge ))
+    route_service_secret: (( merge ))
+
+  loggregator_endpoint:
+    shared_secret: (( merge ))
+
+  dea_next:
+    disk_mb: 199000
+    memory_mb: 28001
+
+  collector:
+    deployment_name: (( meta.environment ))
+
+  acceptance_tests:
+    api:  (( "api." domain ))
+    apps_domain: (( app_domains ))
+    system_domain: (( domain ))
+    client_secret: (( uaa.clients.gorouter.secret ))
+    admin_user: admin
+    admin_password: (( merge ))
+    nodes: 3
+    include_sso: false
+    include_services: false
+    include_logging: false
+    include_v3: false
+    include_routing: false
+    skip_ssl_validation: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+    use_diego: false
+    use_http: true
+
+  smoke_tests:
+    api:  (( "api." domain ))
+    apps_domain: (( app_domains ))
+    user: admin
+    password: (( merge ))
+    org: 'smoke-tests'
+    space: 'smoke-tests'
+    use_existing_org: true
+    skip_ssl_validation: (( merge || false )) # REPLACE_WITH true if your ELB is using a self signed cert
+
+  consul:
+    encrypt_keys: (( merge ))
+    require_ssl: true
+    ca_cert: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
+    agent_cert: (( merge ))
+    agent_key: (( merge ))
+jobs:
+  - name: api_z2
+    instances: 0
+  - name: api_worker_z2
+    instances: 0
+  - name: consul_z1
+    instances: 1
+  - name: consul_z2
+    instances: 0
+  - name: doppler_z2
+    instances: 0
+  - name: etcd_z1
+    instances: 1
+  - name: etcd_z2
+    instances: 0
+  - name: hm9000_z2 
+    instances: 0
+  - name: loggregator_trafficcontroller_z2
+    instances: 0
+  - name: nats_z2
+    instances: 0
+  - name: router_z2
+    instances: 0
+  - name: runner_z2
+    instances: 0
+  - name: smoke_tests
+    instances: 1
+  - name: stats_z2
+    instances: 0
+  - name: uaa_z2
+    instances: 0


### PR DESCRIPTION
Hey all,

I added some stuff that makes it easier to generate the skeleton needed by the deploy_cf_bosh_instance script, and to run the script. I'm working on a [readme update](https://github.com/mavenraven/mega-ci/tree/readme) on how to use it. Hope you guys find this useful. Thanks!

Also, the last two commits shouldn't be merged directly.