### PR TITLE
Concourse setup script fixes

### DIFF
--- a/scripts/setup_aws_bosh_for_concourse
+++ b/scripts/setup_aws_bosh_for_concourse
@@ -76,7 +76,14 @@ if ! aws iam get-server-certificate --server-certificate-name concourse; then
     aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem  --certificate-chain file://${deployment_dir}/artifacts/certs/concourse_chain.pem
   elif [ -e ${deployment_dir}/artifacts/certs/concourse.pem ]; then
     aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem
-  elif [ -n ${CONCOURSE_HOSTNAME} ]; then
+  else
+    if [ -n ${CONCOURSE_HOSTNAME} ]; then
+      if [ -z ${DEFAULT_CONCOURSE_HOSTNAME} ]; then
+        echo 'No concourse key present, so we need to generate one, but DEFAULT_CONCOURSE_HOSTNAME is not set'
+        exit 1
+      fi
+      CONCOURSE_HOSTNAME=${DEFAULT_CONCOURSE_HOSTNAME}
+    fi
     generate_certificate "${deployment_dir}/artifacts/certs" "concourse" ${CONCOURSE_HOSTNAME}
     aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem
   fi

--- a/scripts/setup_aws_bosh_for_concourse
+++ b/scripts/setup_aws_bosh_for_concourse
@@ -61,8 +61,8 @@ if ! aws ec2 describe-key-pairs --key-names bosh; then
 fi
 
 # install certs for CF ELB
-if [ -e ${deployment_dir}/certs/cf.key ] && ! aws iam get-server-certificate --server-certificate-name cf; then
-  aws iam upload-server-certificate --server-certificate-name cf --private-key file://${deployment_dir}/certs/cf.key --certificate-body file://${deployment_dir}/certs/cf.pem
+if [ -e ${deployment_dir}/artifacts/certs/cf.key ] && ! aws iam get-server-certificate --server-certificate-name cf; then
+  aws iam upload-server-certificate --server-certificate-name cf --private-key file://${deployment_dir}/artifacts/certs/cf.key --certificate-body file://${deployment_dir}/artifacts/certs/cf.pem
 fi
 
 # install certs for Concourse ELB
@@ -72,13 +72,13 @@ CONCOURSE_HOSTNAME=$(cat ${deployment_dir}/cloud_formation/properties.json | \
 set -e
 
 if ! aws iam get-server-certificate --server-certificate-name concourse; then
-  if [ -e ${deployment_dir}/certs/concourse_chain.pem ]; then
-    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/certs/concourse.key --certificate-body file://${deployment_dir}/certs/concourse.pem  --certificate-chain file://${deployment_dir}/certs/concourse_chain.pem
-  elif [ -e ${deployment_dir}/certs/concourse.pem ]; then
-    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/certs/concourse.key --certificate-body file://${deployment_dir}/certs/concourse.pem
+  if [ -e ${deployment_dir}/artifacts/certs/concourse_chain.pem ]; then
+    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem  --certificate-chain file://${deployment_dir}/artifacts/certs/concourse_chain.pem
+  elif [ -e ${deployment_dir}/artifacts/certs/concourse.pem ]; then
+    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem
   elif [ -n ${CONCOURSE_HOSTNAME} ]; then
-    generate_certificate "${deployment_dir}/certs" "concourse" ${CONCOURSE_HOSTNAME}
-    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/certs/concourse.key --certificate-body file://${deployment_dir}/certs/concourse.pem
+    generate_certificate "${deployment_dir}/artifacts/certs" "concourse" ${CONCOURSE_HOSTNAME}
+    aws iam upload-server-certificate --server-certificate-name concourse --private-key file://${deployment_dir}/artifacts/certs/concourse.key --certificate-body file://${deployment_dir}/artifacts/certs/concourse.pem
   fi
 fi
 


### PR DESCRIPTION
- looks like the `certs` should be a subdirectory of `artifacts`
- if this is a brand-new deploy and there isn't any concourse hostname, then try to get it from the environment.  because it's required by the cloudformation template.