### PR TITLE
add tag prefix for etcd releases

### DIFF
--- a/pipelines/etcd.yml
+++ b/pipelines/etcd.yml
@@ -198,6 +198,7 @@ jobs:
     params:
       repository: create-final-release/release-repo
       tag: create-final-release/release-repo/version_number
+      tag_prefix: v
 
 
 - name: merge-master-into-develop


### PR DESCRIPTION
Related to [PR](https://github.com/cloudfoundry-incubator/etcd-release/issues/7). Keeping the versioning prefix consistent between cf-release, diego-release, and garden-release.

If you want to rename all the tags and delete the old references:

```
git tag -l | xargs -I '{}' bash -c 'git tag -f v{} {} && git push origin :refs/tags/{}'
git push origin --tags
git tags -l
> v1
v11
v12
v13
v14
v15
v16
v17
v18
v19
v2
v3
v4
v5
v6
v7
v8
v9
```