### PR TITLE
Add test-confab-windows task

### DIFF
--- a/pipelines/consul.yml
+++ b/pipelines/consul.yml
@@ -5,6 +5,7 @@ groups:
   - deploy-bosh-lite-manifests
   - deploy-aws-manifests
   - test-confab
+  - test-confab-windows
   - test-consul
   - deploy-with-cf
   - deploy-with-diego
@@ -181,6 +182,19 @@ jobs:
   - task: test-confab
     file: mega-ci/scripts/ci/confab/test.yml
 
+- name: test-confab-windows
+  public: true
+  serial: true
+  plan:
+  - aggregate:
+    - get: mega-ci
+    - get: consul-release
+      resource: consul-release-develop
+      passed: [check-git-submodules]
+      trigger: true
+  - task: test-confab-windows
+    file: mega-ci/scripts/ci/confab-windows/test.yml
+
 - name: test-consul
   public: true
   serial: true
@@ -189,7 +203,9 @@ jobs:
     - get: mega-ci
     - get: consul-release
       resource: consul-release-develop
-      passed: [test-confab]
+      passed:
+      - test-confab
+      - test-confab-windows
       trigger: true
     - get: stemcell
       resource: aws-stemcell

--- a/scripts/ci/confab-windows/test.ps1
+++ b/scripts/ci/confab-windows/test.ps1
@@ -1,0 +1,45 @@
+trap {
+  write-error $_
+  exit 1
+}
+
+$env:GOPATH = Join-Path -Path $PWD "gopath"
+mkdir -path $env:GOPATH
+$env:PATH = $env:GOPATH + "/bin;C:/go/bin;" + $env:PATH
+
+# Move vendor directory into GOPATH to eliminate long file problems
+mv ./consul-release/src/confab/vendor $env:GOPATH/src
+mkdir -path $env:GOPATH/src/github.com/cloudfoundry-incubator
+mv ./consul-release $env:GOPATH/src/github.com/cloudfoundry-incubator/consul-release
+cd $env:GOPATH/src/github.com/cloudfoundry-incubator/consul-release
+
+if ((Get-Command "go.exe" -ErrorAction SilentlyContinue) -eq $null)
+{
+  Write-Host "Installing Go 1.6.3!"
+  Invoke-WebRequest https://storage.googleapis.com/golang/go1.6.3.windows-amd64.msi -OutFile go.msi
+
+  $p = Start-Process -FilePath "msiexec" -ArgumentList "/passive /norestart /i go.msi" -Wait -PassThru
+
+  if($p.ExitCode -ne 0)
+  {
+    throw "Golang MSI installation process returned error code: $($p.ExitCode)"
+  }
+  Write-Host "Go is installed!"
+}
+
+go.exe install github.com/onsi/ginkgo/ginkgo
+if ($LastExitCode -ne 0)
+{
+    Write-Error $_
+    exit 1
+}
+
+ginkgo.exe -r src/confab -race -randomizeAllSpecs -skipPackage vendor
+if ($LastExitCode -ne 0)
+{
+    Write-Error $_
+    exit 1
+}
+
+Exit 0
+

--- a/scripts/ci/confab-windows/test.yml
+++ b/scripts/ci/confab-windows/test.yml
@@ -1,0 +1,14 @@
+---
+platform: windows
+
+inputs:
+- name: consul-release
+- name: mega-ci
+
+run:
+  path: powershell
+  args:
+  - "-ExecutionPolicy"
+  - "Bypass"
+  - "-File"
+  - mega-ci/scripts/ci/confab-windows/test.ps1


### PR DESCRIPTION
This PR will allow mega-ci to run confab on a Windows VM.

Merging this requires setting up a **Windows** Concourse worker
- A BOSH release to deploy the worker can be found [here](https://github.com/benmoss/concourse-windows-release)
  - The repo's README contains an example BOSH 1.0 manifest but a 2.0 manifest example can be provided if needed
- The latest AWS Windows stemcell can be found [here](https://main.bosh-ci.cf-app.com/teams/main/pipelines/windows-stemcells/resources/bosh-aws-stemcell)

We got the task working with `fly` in our own environment but let us know if any additional configuration for the mega-ci environment is required
